### PR TITLE
Fix incorrect object build code in ModelWrapper

### DIFF
--- a/src/dryml/models/torch/generic.py
+++ b/src/dryml/models/torch/generic.py
@@ -62,7 +62,7 @@ class ModelWrapper(Model):
         self.mdl = None
 
     def compute_prepare_imp(self):
-        self.mdl = self.cls(*self.args, *self.kwargs)
+        self.mdl = self.cls(*self.args, **self.kwargs)
 
 
 class Sequential(Model):


### PR DESCRIPTION
Fixes #12.

- object construction code in dryml.models.torch.general.ModelWrapper was incorrect using *self.kwargs instead of **self.kwargs.