### PR TITLE
Python 3.7 EOL

### DIFF
--- a/.github/workflows/test310.yaml
+++ b/.github/workflows/test310.yaml
@@ -16,13 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install pytest
-          pip install pytest-cov
-          pip install tensorflow
-          pip install ray
-          pip install scikit-learn
-          pip install GPUtil
+          pip install -r test_requirements.txt
 
       - name: Install DRYML
         run: |

--- a/.github/workflows/test311.yaml
+++ b/.github/workflows/test311.yaml
@@ -16,13 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install pytest
-          pip install pytest-cov
-          pip install tensorflow
-          pip install ray
-          pip install scikit-learn
-          pip install GPUtil
+          pip install -r test_requirements.txt
 
       - name: Install DRYML
         run: |

--- a/.github/workflows/test311.yaml
+++ b/.github/workflows/test311.yaml
@@ -1,4 +1,4 @@
-name: Tests Py 3.7
+name: Tests Py 3.11
 
 on: [push]
 
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.11"
 
       - name: Install Dependencies
         run: |
@@ -35,3 +35,9 @@ jobs:
       - name: Run Linter
         run: |
           ./flake.sh
+
+      - name: Send Codecov
+        uses: codecov/codecov-action@v2
+        with: 
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/test38.yaml
+++ b/.github/workflows/test38.yaml
@@ -16,13 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install pytest
-          pip install pytest-cov
-          pip install tensorflow
-          pip install ray
-          pip install scikit-learn
-          pip install GPUtil
+          pip install -r test_requirements.txt
 
       - name: Install DRYML
         run: |

--- a/.github/workflows/test39.yaml
+++ b/.github/workflows/test39.yaml
@@ -16,13 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install pytest
-          pip install pytest-cov
-          pip install tensorflow
-          pip install ray
-          pip install scikit-learn
-          pip install GPUtil
+          pip install -r test_requirements.txt
 
       - name: Install DRYML
         run: |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # DRYML
 
-![Py 3.7 tests](https://github.com/ncsa/dryml/actions/workflows/test37.yaml/badge.svg)
 ![Py 3.8 tests](https://github.com/ncsa/dryml/actions/workflows/test38.yaml/badge.svg)
 ![Py 3.9 tests](https://github.com/ncsa/dryml/actions/workflows/test39.yaml/badge.svg)
 ![Py 3.10 tests](https://github.com/ncsa/dryml/actions/workflows/test310.yaml/badge.svg)
+![Py 3.11 tests](https://github.com/ncsa/dryml/actions/workflows/test311.yaml/badge.svg)
 [![codecov](https://codecov.io/gh/ncsa/dryml/branch/main/graph/badge.svg?token=ELz0TSuOzo)](https://codecov.io/gh/ncsa/dryml)
 
 Don't Repeat Yourself Machine Learning: A Machine Learning library to reduce code duplication, automate testing, perform hyper paramter searches, and ease model serialization.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,6 +4,4 @@ pytest-cov
 tensorflow
 ray
 scikit-learn
-torch
-xgboost
 GPUtil

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,10 @@
+flake8
+pytest
+pytest-cov
+tensorflow
+ray
+scikit-learn
+pytorch
+torch
+xgboost
+GPUtil

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,6 @@ pytest-cov
 tensorflow
 ray
 scikit-learn
-pytorch
 torch
 xgboost
 GPUtil


### PR DESCRIPTION
Python 3.7 is currently EOL. Its time to add 3.11 testing support and drop 3.7.