### PR TITLE
Limit torch version for testing.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,5 +5,5 @@ tensorflow
 ray
 scikit-learn
 xgboost
-torch
+torch<=2.3
 GPUtil


### PR DESCRIPTION
A known issue with torch model serialization causes errors during testing: https://github.com/ncsa/DRYML/issues/23 For now, we'll limit the version used during testing.