### PR TITLE
Fix TorchOptimizer to correctly unpack kwargs

### DIFF
--- a/src/dryml/models/torch/generic.py
+++ b/src/dryml/models/torch/generic.py
@@ -99,7 +99,7 @@ class TorchOptimizer(Object):
         self.opt = self.cls(
             self.model.mdl.parameters(),
             *self.args,
-            *self.kwargs)
+            **self.kwargs)
 
     def load_compute_imp(self, file: zipfile.ZipFile) -> bool:
         try:


### PR DESCRIPTION
Fixes bug in compute_prepare_imp where *kwargs was incorrectly used instead of **kwargs