### PR TITLE
fix: move tensor to CPU before converting to numpy

### DIFF
--- a/src/dryml/data/torch/dataset.py
+++ b/src/dryml/data/torch/dataset.py
@@ -198,7 +198,7 @@ class TorchDataset(Dataset):
         return self.size
 
     def numpy(self):
-        dataset = self.map_el(lambda el: el.detach().numpy())
+        dataset = self.map_el(lambda el: el.detach().cpu().numpy())
         return NumpyDataset(
             dataset.data_gen,
             indexed=dataset.indexed,


### PR DESCRIPTION
added .cpu() call in numpy conversion to prevent CUDA errors